### PR TITLE
Use configurable therapist linking email fallback

### DIFF
--- a/client/src/components/TherapistLinking.tsx
+++ b/client/src/components/TherapistLinking.tsx
@@ -72,10 +72,15 @@ const TherapistLinking: React.FC<TherapistLinkingProps> = ({ onComplete }) => {
   const handleConfirm = async () => {
     try {
       const contactValue = therapistInfo.contactMethod === 'email' ? therapistInfo.email : therapistInfo.phone;
-      
-      // Get current user email (in production this would come from auth context)
-      const currentUserEmail = localStorage.getItem('userEmail') || 'arth.rombus@gmail.com'; // Fallback for testing
-      
+
+      // Get current user email, preferring auth context with an environment-configured fallback
+      const user = await AuthService.getCurrentUser();
+      const currentUserEmail =
+        localStorage.getItem('userEmail') ||
+        user?.email ||
+        import.meta.env.VITE_FALLBACK_USER_EMAIL ||
+        '';
+
       // Send connection request to our backend API with patient email
       const response = await fetch('/api/therapist-connections', {
         method: 'POST',


### PR DESCRIPTION
## Summary
- Replace hard-coded fallback email with configurable value for therapist linking
- Prefer authenticated user email before using environment-provided fallback

## Testing
- ⚠️ `npm test` (missing script: test)
- ✅ `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_68b90511ae9883248c6b80a390e63df0